### PR TITLE
Allow integration of custom cname

### DIFF
--- a/src/utils/generate-url.js
+++ b/src/utils/generate-url.js
@@ -5,9 +5,12 @@ export const generateURL = props => {
   const { src, params, config, containerProps, devicePixelRatio = 1, processURL, processQueryString, service } = props;
   const size = containerProps && containerProps.sizes[DEVICE_PIXEL_RATIO_LIST.indexOf(devicePixelRatio)];
   const { width, height } = size || {};
-  const { token, domain, doNotReplaceURL } = config;
+  const { token, domain, doNotReplaceURL, customDomain } = config;
+
+  const finalDomain = customDomain ? domain : token + '.' + domain;
+
   const url =[
-      doNotReplaceURL ? '' : `https://${token}.${domain}/v7/`,
+      doNotReplaceURL ? '' : `https://${finalDomain}/v7/`,
       src,
       src.includes('?') ? '&' : '?'
   ].join('');


### PR DESCRIPTION
This should allow the plugins to set a custom domain property.

This is useful for where a business wants to use a custom cname instead of the default cloudimage.io URL.

Associated REQUIRED PR on vue-cloudimage-responsive: https://github.com/scaleflex/vue-cloudimage-responsive/pull/4